### PR TITLE
Use the global namespace for the exception class

### DIFF
--- a/Aviate.php
+++ b/Aviate.php
@@ -1,7 +1,7 @@
 <?php
 namespace WeProvide\Aviate;
 
-use Exception;
+use \Exception;
 
 abstract class Aviate {
     protected $hostUrl;


### PR DESCRIPTION
If `.aviate/host.txt` does not exist PHP will throw a class not found exception for the `Exception` class because it's not referenced from the global namespace in the use statement.